### PR TITLE
Don't use empty string as default value

### DIFF
--- a/bing-dict.el
+++ b/bing-dict.el
@@ -173,7 +173,8 @@
    (let* ((default (if (use-region-p)
                        (buffer-substring-no-properties
                         (region-beginning) (region-end))
-                     (substring-no-properties (or (thing-at-point 'word) ""))))
+                     (let ((text (thing-at-point 'word)))
+                       (if text (substring-no-properties text)))))
           (prompt (if (stringp default)
                       (format "Search Bing dict (default \"%s\"): " default)
                     "Search Bing dict: "))


### PR DESCRIPTION
The default value is nil or non-empty string.
